### PR TITLE
Change CdnBaseUrl to CdnFullUrl (match implementation)

### DIFF
--- a/MareSynchronosServer/MareSynchronosServer/appsettings.json
+++ b/MareSynchronosServer/MareSynchronosServer/appsettings.json
@@ -23,7 +23,7 @@
       ]
     }
   },
-  "CdnBaseUrl": "https://<url or ip to your server>/cache/",
+  "CdnFullUrl": "https://<url or ip to your server>/cache/",
   "FailedAuthForTempBan": 5,
   "TempBanDurationInMinutes": 30,
   "DiscordBotToken": "",


### PR DESCRIPTION
This PR fixes an issue with the default `appsettings.json` where `CdnBaseUrl` was specified instead of `CdnFullUrl`, which is what is used in the actual project. On self-hosted servers this leads to a failure to download updated files because of an incorrectly specified URL.