### PR TITLE
stop warning if GeoIP is disabled but city file is non-existent

### DIFF
--- a/MareSynchronosServer/MareSynchronosAuthService/Services/GeoIPService.cs
+++ b/MareSynchronosServer/MareSynchronosAuthService/Services/GeoIPService.cs
@@ -87,7 +87,15 @@ public class GeoIPService : IHostedService
 
                 var useGeoIP = _mareConfiguration.GetValueOrDefault(nameof(AuthServiceConfiguration.UseGeoIP), false);
                 var cityFile = _mareConfiguration.GetValueOrDefault(nameof(AuthServiceConfiguration.GeoIPDbCityFile), string.Empty);
-                var lastWriteTime = new FileInfo(cityFile).LastWriteTimeUtc;
+
+                var lastWriteTime;
+                try {
+                    lastWriteTime = new FileInfo(cityFile).LastWriteTimeUtc;
+                } catch (Exception e) {
+                    _logger.LogDebug($"Unable to get city file info");
+                    lastWriteTime = DateTime.MinTime;
+                }
+
                 if (useGeoIP && (!string.Equals(cityFile, _cityFile, StringComparison.OrdinalIgnoreCase) || lastWriteTime != _dbLastWriteTime))
                 {
                     _cityFile = cityFile;


### PR DESCRIPTION
In PeriodicReloadTask, the GeoIP service keeps trying to reload GeoIP,
presumably in the event that it failed to initialize earlier, or the
configuration has changed.

However, if the city file is invalid, the following log messages can be
seen repeatably in the log every time the GeoIP configuration is
attempted:

  MareSynchronosAuthService.Services.GeoIPService.PeriodicReloadTask(CancellationToken token) in /server/MareSynchronosServer/MareSynchronosAuthService/Services/GeoIPService.cs:line 90
  warn: MareSynchronosAuthService.Services.GeoIPService[0] @ 2024-08-11T18:59:42.3702340+00:00
        Error during periodic GeoIP module reload task, disabling GeoIP
  System.ArgumentException: The value cannot be an empty string. (Parameter 'path')
     at System.ArgumentException.ThrowNullOrEmptyException(String argument, String paramName)
     at System.IO.Path.GetFullPath(String path)
     at System.IO.FileInfo..ctor(String originalPath, String fullPath, String fileName, Boolean isNormalized)
     at MareSynchronosAuthService.Services.GeoIPService.PeriodicReloadTask(CancellationToken token) in /server/MareSynchronosServer/MareSynchronosAuthService/Services/GeoIPService.cs:line 90

This happens because the FileInfo() invocation fails if the cityFile
variable is empty.

Prevent this by catching the errors on getting the lastWriteTime. This
prevents spamming the server log endlessly with warning messages about
GeoIP configuration.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
